### PR TITLE
Remove hardcoded paths from setup

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+parent_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)
+pushd "$parent_path"
 echo "Setting up pool-pi."
 echo "Installing required python packages."
-pip3 install -r /home/pi/Pool-Pi/setup/requirements.txt
+pip3 install -r "$parent_path/requirements.txt"
 echo "Configuring systemd."
-cp /home/pi/Pool-Pi/setup/poolpi.service /etc/systemd/system/poolpi.service
+cp "$parent_path/poolpi.service" /etc/systemd/system/poolpi.service
 chmod 644 /etc/systemd/system/poolpi.service
 systemctl daemon-reload
 systemctl enable --now poolpi.service
-echo "Setup script complete."
+echo "Setup script complete"
+popd


### PR DESCRIPTION
Thanks for your work on this project @ChaseDurand! Looks great.

Ran into a small issue on setup in that I had a different user than what was defined in your original setup file. With this change, you're `pushd`'d into the setup directory where the setup is executed and then `popd`'d back to your original directory on completion. 